### PR TITLE
Fixed Nullable Reference Type On EF Core Project

### DIFF
--- a/Accelist.WebApiStandard.Entities/StandardDb.cs
+++ b/Accelist.WebApiStandard.Entities/StandardDb.cs
@@ -8,6 +8,6 @@ namespace Accelist.WebApiStandard.Entities
         {
         }
 
-        public DbSet<User> Users { get; set; }
+        public DbSet<User> Users => Set<User>();
     }
 }

--- a/Accelist.WebApiStandard.Entities/User.cs
+++ b/Accelist.WebApiStandard.Entities/User.cs
@@ -5,15 +5,15 @@ namespace Accelist.WebApiStandard.Entities
     public class User
     {
         [Key]
-        public string UserID { set; get; }
+        public string? UserID { set; get; }
 
         [Required]
-        public string UserName { set; get; }
+        public string? UserName { set; get; }
 
         [Required]
-        public string FullName { set; get; }
+        public string? FullName { set; get; }
 
         [Required]
-        public string Password { set; get; }
+        public string? Password { set; get; }
     }
 }


### PR DESCRIPTION
This PR will fix the warnings due to the new nullable reference type implementation on .NET 6 for EF Core's `DbContext` setup.